### PR TITLE
add support for dot json keys

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -290,13 +290,13 @@ pub mod tests {
     #[test]
     fn test_selection() {
         // unstructured selection assertion
-        let query = parse(String::from("message=\"pathivu\"")).unwrap();
+        let query = parse(String::from("message = \"pathivu\"")).unwrap();
         let selection = query.selection.unwrap();
         assert_eq!(selection.value, "pathivu");
         assert_eq!(selection.structured, false);
 
         // structured selection assertion
-        let query = parse(String::from("name.location=\"kumari kandam\"")).unwrap();
+        let query = parse(String::from("name.location = \"kumari kandam\"")).unwrap();
         let selection = query.selection.unwrap();
         assert_eq!(selection.value, "kumari kandam");
         assert_eq!(selection.structured, true);
@@ -330,9 +330,12 @@ pub mod tests {
         assert_eq!(distinct.alias, "unique_country");
         assert_eq!(distinct.count, false);
         // distinct_count assertion.
-        let query = parse(String::from("distinct_count(country) as unique_country")).unwrap();
+        let query = parse(String::from(
+            "distinct_count(country.hello/world) as unique_country",
+        ))
+        .unwrap();
         let distinct = query.distinct.unwrap();
-        assert_eq!(distinct.attr, "country");
+        assert_eq!(distinct.attr, "country.hello/world");
         assert_eq!(distinct.alias, "unique_country");
         assert_eq!(distinct.count, true);
     }

--- a/src/parser/query.pest
+++ b/src/parser/query.pest
@@ -13,14 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-unstructured = {"message" ~ SPACE_SEPARATOR* ~ "=" ~ SPACE_SEPARATOR* ~ string}
-flattend_key = {(ASCII_ALPHANUMERIC+ ~".")+ ~ ASCII_ALPHANUMERIC+ | ASCII_ALPHANUMERIC+}
+ unstructured = {"message" ~ SPACE_SEPARATOR* ~ "=" ~ SPACE_SEPARATOR* ~ string}
+
+json_key_char ={
+    (!("\"" | "\\" | ")" | " ") ~ ANY
+    | "\\" ~ ("\"" | "\\" | "/" | "b" | "f" | "n" | "r" | "t")
+    | "\\" ~ ("u" ~ ASCII_HEX_DIGIT{4}) )
+}
+json_key = {json_key_char+}
+flattend_key = {(json_key+ ~".")+ ~ json_key+ | json_key+}
 structured = {flattend_key+ ~ SPACE_SEPARATOR* ~ "=" ~ SPACE_SEPARATOR* ~ string}
 source = {"source" ~ SPACE_SEPARATOR* ~ "=" ~ SPACE_SEPARATOR* ~  ((variable ~",")+ ~ variable | variable)}
-count = {("count("~variable~") as "~variable ~" by " ~ variable)| 
- ("count("~variable~") as "~variable)}
-distinct = {"distinct("~variable~") as "~variable}
+count = {("count("~flattend_key~") as "~variable ~" by " ~ flattend_key)| 
+ ("count("~flattend_key~") as "~variable)}
+distinct = {"distinct("~flattend_key~") as "~variable}
 string = ${ "\"" ~ inner ~ "\"" }
 char = {
     !("\"" | "\\") ~ ANY
@@ -30,8 +36,8 @@ char = {
 
 inner = @{ char* }
 variable = {(ASCII_ALPHANUMERIC+ ~"_")+ ~ ASCII_ALPHANUMERIC+ | ASCII_ALPHANUMERIC+}
-distinct_count = {"distinct_count("~variable~") as "~variable}
-average = {("avg("~variable+~") as "~variable+ ~ " by " ~ variable) | ("avg("~variable+~") as "~variable)}
+distinct_count = {"distinct_count("~flattend_key~") as "~variable}
+average = {("avg("~flattend_key+~") as "~variable+ ~ " by " ~ flattend_key) | ("avg("~flattend_key+~") as "~variable)}
 number = {DECIMAL_NUMBER+}
 limit = {"limit "~ number}
 query_block = {source | count | distinct|distinct_count|average | limit| unstructured | structured}


### PR DESCRIPTION
Previous json parser was not able to detect dot deliminator and keys with dot. This fix will allow user to query using dot key
for example
```json
{
 "k8s.io": "cluster"
}
```
Signed-off-by: balaji jinnah <rbalajis25@gmail.com>